### PR TITLE
Make compatible with latest ecosystem

### DIFF
--- a/nimber.cabal
+++ b/nimber.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.8
 library
   exposed-modules:     Data.Nimber
   build-depends:
-    arithmoi >=0.1,
+    integer-logarithms >=1,
     base ==4.*
   ghc-options:       -Wall
 


### PR DESCRIPTION
This PR enables compilation of `nimber` against current state of Hackage: `Math.NumberTheory.Logarithms` has been moved from `arithmoi` to `integer-logarithms`.